### PR TITLE
fix typo direcotory -> directory

### DIFF
--- a/chrome/locale/en-US/netExport.properties
+++ b/chrome/locale/en-US/netExport.properties
@@ -14,8 +14,8 @@ netexport.menu.tooltip.About=About NetExport extension
 netexport.menu.label.Run_Automated_Loads=Run Automated Loads...
 netexport.menu.tooltip.Run_Automated_Loads=Run suite of pages to measure performance
 
-netexport.menu.label.OpenLogDir=Open Log Direcotory
-netexport.menu.tooltip.OpenLogDir=Open the target direcotory for HAR files
+netexport.menu.label.OpenLogDir=Open Log Directory
+netexport.menu.tooltip.OpenLogDir=Open the target directory for HAR files
 
 # LOCALIZATION NOTE (netexport.menu.label.Options): Label for options menu.
 netexport.menu.label.Options=Options


### PR DESCRIPTION
Hi, 
I fix this small typo under tab: `Net > Export > Open Log Direcotory`

thnx for usefull tool anyway .)

marek
