### PR TITLE
Issue 5971: programmatic triggering of NetExport

### DIFF
--- a/chrome/content/netexport/automation.js
+++ b/chrome/content/netexport/automation.js
@@ -321,9 +321,13 @@ Firebug.NetExport.PageLoadObserver.prototype =
                 if (t !== token && FBTrace.DBG_NETEXPORT) {
                     FBTrace.sysout("netexport.Automation; " +
                                    "invalid token");
-                    return undefined;
+                    throw {
+                        name:    "Invalid security token",
+                        message: "The provided security token is incorrect"
+                    };
                 }
-                return f;
+                var args = Array.prototype.slice.call(arguments, 1);
+                return f.apply(this, args);
             };
         };
         for (var f in functions) {

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -25,6 +25,10 @@ pref("extensions.firebug.netexport.sendToConfirmation", true);
 // Number of milliseconds to wait after the last page request to declare the page loaded.
 pref("extensions.firebug.netexport.pageLoadedTimeout", 1500);
 
+// Secret token for exporting helper functions to user window. If
+// empty, no functions are exported.
+pref("extensions.firebug.netexport.secretToken", "");
+
 // Number of milliseconds to wait after the page is exported even if not loaded yet.
 // Set to zero to switch off this feature.
 pref("extensions.firebug.netexport.timeout", 60000);


### PR DESCRIPTION
An export can be triggered with
`window.NetExport.triggerExport("token")()`. Automatic export has to
be enabled for this function to be available. However, it is possible
to disable unattended automatic export by setting the timeout to 0.

Since we don't want any page to trigger an export, `token` is a
security token that should be kept secret and is set by the user in
`extensions.firebug.netexport.secretToken`. If the token is incorrect,
it is not possible to call the final function.

It should be easy to add other functions like this. I have tried to be secure in how the function is exported. Keep in mind I am not familiar with extensions.
